### PR TITLE
[MotionDetection]Use single draw to mix camera preview and motion texture

### DIFF
--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
@@ -5,7 +5,7 @@ import android.opengl.GLES20
 import android.os.Handler
 import androidx.tracing.trace
 import org.avmedia.remotevideocam.camera.VideoProcessorImpl
-import org.opencv.android.OpenCVLoader
+import org.avmedia.remotevideocam.opengl.GlMixTextureDrawer
 import org.opencv.core.MatOfPoint
 import org.webrtc.GlRectDrawer
 import org.webrtc.GlTextureFrameBuffer
@@ -26,6 +26,10 @@ private val matToTextureTransform = Matrix().apply {
     preTranslate(-0.5f, -0.5f)
 }
 
+private val identityMatrix = FloatArray(16).apply {
+    android.opengl.Matrix.setIdentityM(this, 0)
+}
+
 private const val TAG = "MotionProcessor"
 
 /**
@@ -44,6 +48,7 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
     private val yuvConverter = YuvConverter()
     private val glDrawer = GlRectDrawer()
     private val motionDetector = MotionDetector()
+    private var textureDrawer: GlMixTextureDrawer? = null
 
     private var texId: Int? = null
     private var listener: Listener? = null
@@ -106,7 +111,12 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
 
         // TODO: optimize perf with a single framebuffer
         val frameBuffer = GlTextureFrameBuffer(GLES20.GL_RGBA)
-        renderToTexture(frameBuffer, textureFrame, texId)
+        frameBuffer.setSize(width, height)
+        if (false) {
+            renderToTexture(frameBuffer, textureFrame, texId)
+        } else {
+            renderToTexture2(frameBuffer, textureFrame, texId)
+        }
 
         return@trace TextureBufferImpl(
             width,
@@ -120,13 +130,39 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         )
     }
 
+    private fun renderToTexture2(
+        frameBuffer: GlTextureFrameBuffer,
+        cameraTextureBuffer: TextureBuffer,
+        maskTexId: Int,
+    ) = trace("$TAG.renderToTexture2") {
+        GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, frameBuffer.frameBufferId)
+
+        val cameraTransform =
+            RendererCommon.convertMatrixFromAndroidGraphicsMatrix(cameraTextureBuffer.transformMatrix)
+        val textureDrawer = this.textureDrawer ?: GlMixTextureDrawer().also {
+            it.init()
+            this.textureDrawer = it
+        }
+        textureDrawer.draw(
+            0,
+            0,
+            cameraTextureBuffer.width,
+            cameraTextureBuffer.height,
+            cameraTextureBuffer.textureId,
+            cameraTransform,
+            maskTexId,
+        )
+
+        GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0)
+
+        GLES20.glFlush()
+    }
+
     private fun renderToTexture(
         frameBuffer: GlTextureFrameBuffer,
         cameraTextureBuffer: TextureBuffer,
         texId: Int
     ) = trace("$TAG.renderToTexture") {
-        frameBuffer.setSize(cameraTextureBuffer.width, cameraTextureBuffer.height)
-
         GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, frameBuffer.frameBufferId)
 
         // Render camera frame
@@ -173,5 +209,7 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         }
         glDrawer.release()
         yuvConverter.release()
+        textureDrawer?.release()
+        textureDrawer = null
     }
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/opengl/GlMixTextureDrawer.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/opengl/GlMixTextureDrawer.kt
@@ -1,0 +1,148 @@
+package org.avmedia.remotevideocam.opengl
+
+import android.opengl.GLES11Ext
+import android.opengl.GLES20
+import org.webrtc.GlShader
+import org.webrtc.GlUtil
+
+private const val TAG = "GlTextureDrawer"
+class GlMixTextureDrawer {
+
+    private val FULL_RECTANGLE_VERTEX_BUFFER = GlUtil.createFloatBuffer(
+        floatArrayOf(
+            -1f, -1f, // bottom left
+            1f, -1f, // bottom right
+            -1f, 1f, // top left
+            1f, 1f,  // top right
+        )
+    )
+
+    private val FULL_RECTANGLE_TEXTURE_BUFFER = GlUtil.createFloatBuffer(
+        floatArrayOf(
+            0f, 0f, // bottom left
+            1f, 0f, // bottom right
+            0f, 1f, // top left
+            1f, 1f, // top right
+        )
+    )
+
+    object ShaderSource {
+        val POSITION_NAME = "aPosition"
+        val TEXCOORD_NAME = "aTexCoord"
+        val TEXMATRIX_NAME = "uTexMatrix"
+        val VARYING_TEXCOORD_NAME = "vTexCoord"
+        val MASK_TEX_NAME = "uMaskTex"
+        val EXTERNAL_TEX_NAME = "uExtTex"
+
+        val vertexShader =
+            """
+            attribute vec4 $POSITION_NAME;
+            attribute vec4 $TEXCOORD_NAME;
+            uniform mat4 $TEXMATRIX_NAME;
+            
+            varying vec2 $VARYING_TEXCOORD_NAME;
+            
+            void main() {
+                gl_Position = vec4($POSITION_NAME.x, $POSITION_NAME.y, 1, 1);
+                $VARYING_TEXCOORD_NAME = ($TEXMATRIX_NAME * $TEXCOORD_NAME).xy;
+            }
+        """.trimIndent()
+
+        val fragmentShader =
+            """
+            #extension GL_OES_EGL_image_external : require
+            
+            precision mediump float;
+            uniform samplerExternalOES $EXTERNAL_TEX_NAME;
+            uniform sampler2D $MASK_TEX_NAME;
+            
+            varying vec2 $VARYING_TEXCOORD_NAME;
+            
+            void main() {
+                vec4 mask_color = texture2D($MASK_TEX_NAME, $VARYING_TEXCOORD_NAME);
+                vec4 external_color = texture2D($EXTERNAL_TEX_NAME, $VARYING_TEXCOORD_NAME);
+                gl_FragColor = mix(external_color, mask_color, mask_color.a);
+            }
+        """.trimIndent()
+    }
+
+    private var shader : GlShader? = null
+    private var positionLocation = 0
+    private var texCoordLocation = 0
+    private var texTransformLocation = 0
+    private var maskTexLocation = 0
+    private var externalTexLocation = 0
+    private val active get() = shader != null
+
+    fun init() {
+        val shader = GlShader(ShaderSource.vertexShader, ShaderSource.fragmentShader).also {
+            this.shader = it
+        }
+        shader.useProgram()
+        positionLocation = shader.getAttribLocation(ShaderSource.POSITION_NAME)
+        texCoordLocation = shader.getAttribLocation(ShaderSource.TEXCOORD_NAME)
+        texTransformLocation = shader.getUniformLocation(ShaderSource.TEXMATRIX_NAME)
+        maskTexLocation = shader.getUniformLocation(ShaderSource.MASK_TEX_NAME)
+        externalTexLocation = shader.getUniformLocation(ShaderSource.EXTERNAL_TEX_NAME)
+
+        // Assign texture unit
+        GLES20.glUniform1i(externalTexLocation, 0)
+        GLES20.glUniform1i(maskTexLocation, 1)
+
+        // Assign vertex and texture coordinate attributes
+        GLES20.glEnableVertexAttribArray(positionLocation)
+        GLES20.glVertexAttribPointer(
+            positionLocation,
+            2,
+            GLES20.GL_FLOAT,
+            false,
+            0,
+            FULL_RECTANGLE_VERTEX_BUFFER
+        )
+        GLES20.glEnableVertexAttribArray(texCoordLocation)
+        GLES20.glVertexAttribPointer(
+            texCoordLocation,
+            2,
+            GLES20.GL_FLOAT,
+            false,
+            0,
+            FULL_RECTANGLE_TEXTURE_BUFFER
+        )
+
+        GlUtil.checkNoGLES2Error("$TAG.init")
+    }
+
+    fun draw(
+        viewportX: Int,
+        viewportY: Int,
+        viewportWidth: Int,
+        viewportHeight: Int,
+        externalTexId: Int,
+        externalTransform: FloatArray,
+        maskTexId: Int,
+    ) {
+        shader?.useProgram()
+
+        // bind textures
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
+        GLES20.glBindTexture(GLES11Ext.GL_TEXTURE_EXTERNAL_OES, externalTexId)
+        GLES20.glActiveTexture(GLES20.GL_TEXTURE1)
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, maskTexId)
+
+        GLES20.glViewport(viewportX, viewportY, viewportWidth, viewportHeight)
+        GLES20.glUniformMatrix4fv(
+            texTransformLocation,
+            1,
+            false,
+            externalTransform,
+            0
+        )
+        GLES20.glDrawArrays(GLES20.GL_TRIANGLE_STRIP, 0, 4)
+        GlUtil.checkNoGLES2Error("$TAG.draw")
+    }
+
+    fun release() {
+        shader?.release()
+        shader = null
+    }
+}


### PR DESCRIPTION
name | time | count | agg
-- | -- | -- | -- 
MotionProcessor.renderToTexture | 207ms 33us 358ns | 31 | 6.67ms
MotionProcessor.renderToTexture2 | 59ms 856us 289ns |  40 | 1.475ms


It seems like a -77% improvement by merging two render pass into one.