### PR TITLE
[MotionDetection]optimize backgroundsubstractor

### DIFF
--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
@@ -2,6 +2,7 @@ package org.avmedia.remotevideocam.frameanalysis.motion
 
 import android.opengl.GLES20
 import androidx.tracing.trace
+import org.avmedia.remotevideocam.frameanalysis.motion.backgroundsubtractor.BackgroundSubtractor
 import org.avmedia.remotevideocam.frameanalysis.motion.backgroundsubtractor.FrameDiffSubtractor
 import org.opencv.android.OpenCVLoader
 import org.opencv.core.CvType
@@ -12,6 +13,7 @@ import org.opencv.core.Scalar
 import org.opencv.core.Size
 import org.opencv.imgproc.Imgproc
 import org.webrtc.TextureBufferImpl
+import timber.log.Timber
 import java.nio.ByteBuffer
 
 private const val GRAY_SCALE_THRESHOLD = 20.0
@@ -25,11 +27,9 @@ private const val TAG = "MotionDetector"
  * Use OpenCV to detect the motion of two consecutive frames. It finds contours of the foreground
  * image to conclude the motion detection result.
  */
-class MotionDetector {
-
-    private val backgroundSubtractor by lazy {
-        FrameDiffSubtractor()
-    }
+class MotionDetector(
+    private val backgroundSubtractor: BackgroundSubtractor = FrameDiffSubtractor()
+) {
 
     private val morphKernel by lazy {
         Imgproc.getStructuringElement(
@@ -39,12 +39,6 @@ class MotionDetector {
     }
 
     private var byteBufferToTexture: ByteBuffer? = null
-
-    init {
-        check(OpenCVLoader.initLocal()) {
-            "Fail to init OpenCV"
-        }
-    }
 
     fun analyzeMotion(textureBuffer: TextureBufferImpl): List<MatOfPoint> =
         trace("$TAG.analyzeMotion") {
@@ -154,5 +148,14 @@ class MotionDetector {
 
     fun release() {
         backgroundSubtractor.release()
+    }
+
+    companion object {
+        init {
+            Timber.tag(TAG).i("Initialize OpenCV")
+            check(OpenCVLoader.initLocal()) {
+                "Fail to init OpenCV"
+            }
+        }
     }
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
@@ -107,7 +107,7 @@ class MotionDetector {
 
     private fun executeImageProcessing(foregroundMat: Mat) =
         trace("executeImageProcessing") {
-            trace("makeBinaryImage") {
+            trace("binarizeImage") {
                 // Create a binary image with a gray scale threshold.
                 Imgproc.threshold(
                     foregroundMat,
@@ -118,7 +118,7 @@ class MotionDetector {
                 )
             }
 
-            trace("noiseReduction") {
+            trace("reduceNoise") {
                 /**
                  * Noise reduction choices
                  * 1. MORPH_OPEN to reduce random noises from the foreground.

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
@@ -151,4 +151,8 @@ class MotionDetector {
         )
         return@trace contours.filter { it.width() * it.height() >= minArea }
     }
+
+    fun release() {
+        backgroundSubtractor.release()
+    }
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionDetector.kt
@@ -72,10 +72,10 @@ class MotionDetector {
         val mat = Mat(height, width, CvType.CV_8UC4, byteBuffer)
 
         // Clear the mat with transparent black.
-        Imgproc.rectangle(mat, Rect(0, 0, width, height), SCALAR_TRANSPARENT, -1)
+        Imgproc.rectangle(mat, Rect(0, 0, width, height), SCALAR_TRANSPARENT, Imgproc.FILLED)
 
         // Draw contours with green outlines.
-        Imgproc.drawContours(mat, filtered, -1, SCALAR_GREEN)
+        Imgproc.drawContours(mat, filtered, -1, SCALAR_GREEN, Imgproc.FILLED)
 
         GLES20.glActiveTexture(GLES20.GL_TEXTURE0)
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, texId)

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
@@ -5,7 +5,6 @@ import android.opengl.GLES20
 import android.os.Handler
 import androidx.tracing.trace
 import org.avmedia.remotevideocam.camera.VideoProcessorImpl
-import org.opencv.android.OpenCVLoader
 import org.opencv.core.MatOfPoint
 import org.webrtc.GlRectDrawer
 import org.webrtc.GlTextureFrameBuffer
@@ -64,10 +63,11 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
     private fun processInternal(frame: VideoFrame): VideoFrame {
         val textureBuffer = frame.buffer as TextureBufferImpl
         val contours = motionDetector.analyzeMotion(textureBuffer)
+        val motionDetected = contours.isNotEmpty()
 
-        notifyListener(contours)
+        notifyListener(motionDetected)
 
-        val resultBuffer = if (renderMotion) {
+        val resultBuffer = if (motionDetected && renderMotion) {
             val modifiedBuffer = modifyTextureBuffer(textureBuffer, contours)
             VideoFrame(modifiedBuffer, frame.rotation, frame.timestampNs)
         } else {
@@ -86,8 +86,7 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         this.renderMotion = renderMotion
     }
 
-    private fun notifyListener(contours: List<MatOfPoint>) {
-        val motionDetected = contours.isNotEmpty()
+    private fun notifyListener(motionDetected: Boolean) {
         listener?.onDetectionResult(motionDetected)
     }
 

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
@@ -43,7 +43,9 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
 
     private val yuvConverter = YuvConverter()
     private val glDrawer = GlRectDrawer()
-    private val motionDetector = MotionDetector()
+    private val motionDetector by lazy {
+        MotionDetector()
+    }
 
     private var texId: Int? = null
     private var listener: Listener? = null
@@ -82,7 +84,7 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         return resultBuffer
     }
 
-    fun setMotionListener(listener: Listener?, renderMotion: Boolean = true) {
+    fun setMotionListener(listener: Listener?, renderMotion: Boolean = false) {
         Timber.tag(TAG).i(
             "setMotionListener, listener %s, renderMotion %s",
             listener,

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
@@ -82,7 +82,7 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         return resultBuffer
     }
 
-    fun setMotionListener(listener: Listener?, renderMotion: Boolean = false) {
+    fun setMotionListener(listener: Listener?, renderMotion: Boolean = true) {
         Timber.tag(TAG).i(
             "setMotionListener, listener %s, renderMotion %s",
             listener,

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionProcessor.kt
@@ -172,5 +172,6 @@ class MotionProcessor : VideoProcessorImpl.FrameProcessor {
         }
         glDrawer.release()
         yuvConverter.release()
+        motionDetector.release()
     }
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/BackgroundSubtractor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/BackgroundSubtractor.kt
@@ -1,0 +1,11 @@
+package org.avmedia.remotevideocam.frameanalysis.motion.backgroundsubtractor
+
+import org.opencv.core.Mat
+import org.webrtc.TextureBufferImpl
+
+interface BackgroundSubtractor {
+
+    fun apply(textureBufferImpl: TextureBufferImpl): Mat?
+
+    fun release()
+}

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/BackgroundSubtractor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/BackgroundSubtractor.kt
@@ -2,10 +2,18 @@ package org.avmedia.remotevideocam.frameanalysis.motion.backgroundsubtractor
 
 import org.opencv.core.Mat
 import org.webrtc.TextureBufferImpl
+import org.webrtc.VideoFrame
 
+/**
+ * Used to segment the foreground objects from the background scene.
+ */
 interface BackgroundSubtractor {
 
-    fun apply(textureBufferImpl: TextureBufferImpl): Mat?
+    /**
+     * @param buffer the latest video buffer
+     * @return the mat of foreground objects
+     */
+    fun apply(buffer: VideoFrame.Buffer): Mat?
 
     fun release()
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
@@ -51,6 +51,8 @@ class FrameDiffSubtractor : BackgroundSubtractor {
 
     override fun release() {
         lastFrame?.release()
+        lastFrame = null
+
         foreground.release()
     }
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
@@ -1,0 +1,56 @@
+package org.avmedia.remotevideocam.frameanalysis.motion.backgroundsubtractor
+
+import androidx.tracing.trace
+import org.opencv.core.Core
+import org.opencv.core.CvType
+import org.opencv.core.Mat
+import org.webrtc.TextureBufferImpl
+import org.webrtc.VideoFrame
+
+private const val TAG = "FrameDiffSubtractor"
+
+class FrameDiffSubtractor : BackgroundSubtractor {
+    class Frame(
+        private val buffer: VideoFrame.I420Buffer,
+    ) {
+        val mat = Mat(buffer.height, buffer.width, CvType.CV_8UC1, buffer.dataY)
+
+        val width get() = mat.width()
+
+        val height get() = mat.height()
+
+        fun release() = buffer.release()
+    }
+
+    private var lastFrame: Frame? = null
+    private val foreground = Mat()
+
+    override fun apply(textureBufferImpl: TextureBufferImpl): Mat? = trace("$TAG.apply") {
+        val frame = trace("toI420") {
+            Frame(textureBufferImpl.toI420())
+        }
+
+        if (lastFrame == null ||
+            lastFrame?.width != frame.width ||
+            lastFrame?.height != frame.height) {
+            lastFrame?.release()
+            lastFrame = frame
+            return@trace null
+        }
+
+        val lastFrame = checkNotNull(this.lastFrame)
+        trace("extractForeground") {
+            Core.absdiff(lastFrame.mat, frame.mat, foreground)
+        }
+
+        lastFrame.release()
+        this.lastFrame = frame
+
+        return@trace foreground
+    }
+
+    override fun release() {
+        lastFrame?.release()
+        foreground.release()
+    }
+}

--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/backgroundsubtractor/FrameDiffSubtractor.kt
@@ -4,7 +4,6 @@ import androidx.tracing.trace
 import org.opencv.core.Core
 import org.opencv.core.CvType
 import org.opencv.core.Mat
-import org.webrtc.TextureBufferImpl
 import org.webrtc.VideoFrame
 
 private const val TAG = "FrameDiffSubtractor"
@@ -25,9 +24,9 @@ class FrameDiffSubtractor : BackgroundSubtractor {
     private var lastFrame: Frame? = null
     private val foreground = Mat()
 
-    override fun apply(textureBufferImpl: TextureBufferImpl): Mat? = trace("$TAG.apply") {
+    override fun apply(buffer: VideoFrame.Buffer): Mat? = trace("$TAG.apply") {
         val frame = trace("toI420") {
-            Frame(textureBufferImpl.toI420())
+            Frame(buffer.toI420())
         }
 
         if (lastFrame == null ||


### PR DESCRIPTION
Using advanced background subtractors slow down the computation, averaging 80% of executeImageProcessing budget.

<img width="426" alt="image" src="https://github.com/user-attachments/assets/91608a80-11eb-4321-ab23-c7bd2f35c9a4">

Our use case is pretty simple and always adapt the new frame as the latest frame. Thus, frame diff is a better choice with good performance less than 1ms. 

