### PR TITLE
[MotionDetection]use 12-hour format for notification

### DIFF
--- a/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionNotificationController.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/frameanalysis/motion/MotionNotificationController.kt
@@ -72,7 +72,7 @@ class MotionNotificationController(private val context: Context) {
         }
 
         val simpleDataFormat = SimpleDateFormat(
-            "HH:mm:ss",
+            "hh:mm:ss a",
             Locale.getDefault())
             .format(Date())
 


### PR DESCRIPTION
* change to use 12-hour format
* always use the local time aligned with the device timezone / system.

<img width="260" alt="image" src="https://github.com/user-attachments/assets/c333ac1a-3316-4fe4-92cb-d9f792287463">
