### PR TITLE
Show video frame statistics for frozen video detection

### DIFF
--- a/app/src/main/java/org/avmedia/remotevideocam/MainActivity.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/MainActivity.kt
@@ -99,7 +99,7 @@ class MainActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks,
             )
             Display.connect(this)
 
-            Camera.init(this, binding.videoWindow)
+            Camera.init(this, binding.videoWindow, binding.cameraToggle)
             Camera.connect(this)
         }
     }

--- a/app/src/main/java/org/avmedia/remotevideocam/MainActivity.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/MainActivity.kt
@@ -91,7 +91,12 @@ class MainActivity : AppCompatActivity(), EasyPermissions.PermissionCallbacks,
 
         if (!Camera.isConnected()) {
             // Open display first, which waits on 'accept'
-            Display.init(this, binding.videoView, binding.motionDetectionButton)
+            Display.init(
+                this,
+                binding.videoView,
+                binding.motionDetectionButton,
+                binding.videoStreamIndicator
+            )
             Display.connect(this)
 
             Camera.init(this, binding.videoWindow)

--- a/app/src/main/java/org/avmedia/remotevideocam/camera/Camera.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/camera/Camera.kt
@@ -23,6 +23,7 @@ object Camera {
     fun init(
         context: Context?,
         view: WebRTCSurfaceView,
+        cameraToggle: ImageButton,
     ) {
         this.context = context
 
@@ -34,6 +35,12 @@ object Camera {
 
         handleDisplayEvents()
         handleDisplayCommands()
+
+        cameraToggle.setOnClickListener {
+            cameraToggle.isSelected = !cameraToggle.isSelected
+            val enable = !cameraToggle.isSelected
+            videoServer.setCameraCapturer(enable)
+        }
     }
 
     internal class DataReceived : IDataReceived {

--- a/app/src/main/java/org/avmedia/remotevideocam/camera/IVideoServer.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/camera/IVideoServer.kt
@@ -17,4 +17,5 @@ interface IVideoServer {
     fun setView(view: SurfaceView?)
     fun setView(view: TextureView?)
     fun setView(view: SurfaceViewRenderer?)
+    fun setCameraCapturer(enabled: Boolean)
 }

--- a/app/src/main/java/org/avmedia/remotevideocam/camera/WebRtcServer.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/camera/WebRtcServer.kt
@@ -118,6 +118,19 @@ class WebRtcServer : IVideoServer, MotionProcessor.Listener {
         andGate?.set("view set", true)
     }
 
+    override fun setCameraCapturer(enabled: Boolean) {
+        Timber.tag(TAG).d("setCamera ")
+        if (enabled) {
+            videoCapturer?.startCapture(
+                VIDEO_RESOLUTION_WIDTH,
+                VIDEO_RESOLUTION_HEIGHT,
+                FPS,
+            )
+        } else {
+            videoCapturer?.stopCapture()
+        }
+    }
+
     override fun setConnected(connected: Boolean) {
         andGate?.set("connected", connected)
     }

--- a/app/src/main/java/org/avmedia/remotevideocam/display/Display.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/display/Display.kt
@@ -3,6 +3,7 @@ package org.avmedia.remotevideocam.display
 import android.annotation.SuppressLint
 import android.content.Context
 import android.widget.ImageButton
+import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import org.avmedia.remotevideocam.display.customcomponents.VideoViewWebRTC
 import org.avmedia.remotevideocam.frameanalysis.motion.MotionDetectionRemoteController
@@ -11,15 +12,18 @@ import org.avmedia.remotevideocam.frameanalysis.motion.MotionDetectionRemoteCont
 object Display : Fragment() {
     private var connection: ILocalConnection = NetworkServiceConnection
     private val motionDetectionRemoteController = MotionDetectionRemoteController(connection)
+    private val videoStreamStatusController = VideoStreamStatusController()
 
     fun init(
         context: Context,
         videoView: VideoViewWebRTC,
-        motionDetectionButton: ImageButton
+        motionDetectionButton: ImageButton,
+        videoStreamIndicator: ImageView
     ) {
         connection.init(context)
         videoView.init()
         CameraDataListener.init(connection)
+        videoStreamStatusController.init(videoStreamIndicator, videoView)
 
         motionDetectionRemoteController.init(context)
         motionDetectionButton.setOnClickListener {

--- a/app/src/main/java/org/avmedia/remotevideocam/display/VideoStreamStatusController.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/display/VideoStreamStatusController.kt
@@ -1,0 +1,45 @@
+package org.avmedia.remotevideocam.display
+
+import android.graphics.Color
+import android.os.Handler
+import android.os.Looper
+import android.os.SystemClock
+import android.widget.ImageView
+import org.avmedia.remotevideocam.display.customcomponents.VideoViewWebRTC
+import timber.log.Timber
+
+private const val TAG = "VideoStreamStatusController"
+class VideoStreamStatusController {
+
+    lateinit var view: ImageView
+    lateinit var viewWebRTC: VideoViewWebRTC
+
+    private val handler = Handler(Looper.getMainLooper())
+
+    fun init(view: ImageView, videoViewWebRTC: VideoViewWebRTC) {
+        this.view = view
+        this.viewWebRTC = videoViewWebRTC
+
+        checkStatus()
+    }
+
+    private fun checkStatus() {
+        val frozen = SystemClock.elapsedRealtime() - viewWebRTC.videoFrameSystemClockMs > 1_000
+        Timber.tag(TAG).d("frozen $frozen, current ${SystemClock.elapsedRealtime()}, last ${viewWebRTC.videoFrameSystemClockMs}")
+        updateStatus(frozen)
+
+        handler.removeCallbacksAndMessages(null)
+        handler.postDelayed({
+            checkStatus()
+        }, 1_000)
+    }
+
+    private fun updateStatus(frozen: Boolean) {
+        val filter = if (frozen) {
+            Color.RED
+        } else {
+            Color.GREEN
+        }
+        view.setColorFilter(filter)
+    }
+}

--- a/app/src/main/java/org/avmedia/remotevideocam/display/customcomponents/VideoViewWebRTC.kt
+++ b/app/src/main/java/org/avmedia/remotevideocam/display/customcomponents/VideoViewWebRTC.kt
@@ -11,6 +11,7 @@ package org.avmedia.remotevideocam.display.customcomponents
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.SystemClock
 import android.util.AttributeSet
 import io.reactivex.android.schedulers.AndroidSchedulers
 import io.reactivex.disposables.Disposable
@@ -33,6 +34,9 @@ class VideoViewWebRTC @JvmOverloads constructor(
     private var factory: PeerConnectionFactory? = null
     private val connection: ILocalConnection = NetworkServiceConnection
     private var mirrorState = false
+
+    var videoFrameSystemClockMs: Long = -1
+        private set
 
     companion object {
         private const val TAG = "VideoViewWebRTC"
@@ -63,6 +67,11 @@ class VideoViewWebRTC @JvmOverloads constructor(
         createAppEventsSubscription()
 
         rootEglBase = EglBase.create()
+    }
+
+    override fun onFrame(frame: VideoFrame) {
+        super.onFrame(frame)
+        videoFrameSystemClockMs = SystemClock.elapsedRealtime()
     }
 
     private fun processVideoCommand(command: String) {

--- a/app/src/main/res/drawable/circle.xml
+++ b/app/src/main/res/drawable/circle.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FFFF0000"/>
+</shape>

--- a/app/src/main/res/drawable/ic_videocam_24.xml
+++ b/app/src/main/res/drawable/ic_videocam_24.xml
@@ -1,0 +1,13 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="40dp"
+    android:height="40dp"
+    android:tint="#000000"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    >
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M17,10.5V7c0,-0.55 -0.45,-1 -1,-1H4c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.55,0 1,-0.45 1,-1v-3.5l4,4v-11l-4,4z" />
+
+</vector>

--- a/app/src/main/res/drawable/ic_videocam_off_24.xml
+++ b/app/src/main/res/drawable/ic_videocam_off_24.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true"
+    android:width="40dp"
+    android:height="40dp"
+    android:tint="#000000"
+    android:viewportHeight="24"
+    android:viewportWidth="24"
+    >
+
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M21,6.5l-4,4V7c0,-0.55 -0.45,-1 -1,-1H9.82L21,17.18V6.5zM3.27,2L2,3.27 4.73,6H4c-0.55,0 -1,0.45 -1,1v10c0,0.55 0.45,1 1,1h12c0.21,0 0.39,-0.08 0.54,-0.18L19.73,21 21,19.73 3.27,2z" />
+
+</vector>

--- a/app/src/main/res/drawable/videocam_toggle.xml
+++ b/app/src/main/res/drawable/videocam_toggle.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <item
+        android:state_selected="false"
+        android:drawable="@color/white"
+        />
+
+<!--    <item-->
+<!--        android:state_selected="true"-->
+<!--        android:drawable="@color/green"-->
+<!--        />-->
+
+</selector>

--- a/app/src/main/res/drawable/videocam_toggle.xml
+++ b/app/src/main/res/drawable/videocam_toggle.xml
@@ -3,12 +3,12 @@
 
     <item
         android:state_selected="false"
-        android:drawable="@color/white"
+        android:drawable="@drawable/ic_videocam_24"
         />
 
-<!--    <item-->
-<!--        android:state_selected="true"-->
-<!--        android:drawable="@color/green"-->
-<!--        />-->
+    <item
+        android:state_selected="true"
+        android:drawable="@drawable/ic_videocam_off_24"
+        />
 
 </selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -180,6 +180,17 @@
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 
+        <ImageView
+            android:id="@+id/video_stream_indicator"
+            android:layout_marginTop="5dp"
+            android:layout_width="10dp"
+            android:layout_height="10dp"
+            android:layout_centerHorizontal="true"
+            android:layout_alignParentTop="true"
+            android:src="@drawable/circle"
+            app:tint="@color/green"
+            />
+
         <LinearLayout
             android:id="@+id/display_top_buttons_layout"
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -132,10 +132,11 @@
                 android:layout_width="50dp"
                 android:layout_height="50dp"
                 android:background="@drawable/button"
-                app:tint="@color/selector_tint"
-                android:src="@drawable/ic_videocam_off_24"
+                app:tint="@color/white"
+                android:src="@drawable/videocam_toggle"
                 android:layout_margin="5dp"
                 />
+<!--            app:tint="@color/selector_tint"-->
 
             <org.avmedia.remotevideocam.camera.customcomponents.FlipCamera
                 android:id="@+id/ic_flip_camera"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -123,7 +123,19 @@
             android:layout_alignParentBottom="true"
             android:background="@drawable/shaded"
             android:orientation="vertical"
+            android:gravity="center_horizontal"
             app:layout_constraintBottom_toBottomOf="parent">
+
+            <ImageButton
+                android:id="@+id/camera_toggle"
+                style="@style/IconOnlyButton"
+                android:layout_width="50dp"
+                android:layout_height="50dp"
+                android:background="@drawable/button"
+                app:tint="@color/selector_tint"
+                android:src="@drawable/ic_videocam_off_24"
+                android:layout_margin="5dp"
+                />
 
             <org.avmedia.remotevideocam.camera.customcomponents.FlipCamera
                 android:id="@+id/ic_flip_camera"
@@ -258,9 +270,10 @@
             android:layout_alignParentRight="true"
             android:background="@drawable/shaded"
             app:tint="@color/selector_tint"
-            android:src="@drawable/ic_motion_detection"
+            android:src="@drawable/ic_videocam_off_24"
             android:padding="5dp"
             />
+<!--        android:src="@drawable/ic_motion_detection"-->
 
     </org.avmedia.remotevideocam.display.customcomponents.DisplayLayout>
 


### PR DESCRIPTION
|camera toggle| froze video indicator
|-|-
|![output](https://github.com/user-attachments/assets/796aec11-473a-48b1-9066-e9fcdc947ff9)|![output](https://github.com/user-attachments/assets/b9e6d480-2fad-4272-9704-c9fbb34fb469)
|User can turn off the video stream by toggling the videocam button. It is useful for pure security cam use case where turning off camera avoids battery consumption and heat |A indicator detects video stream status and turns red after being stuck for more than 1 second. It turns green when videos stream recovers.